### PR TITLE
Fix #29 Accept mqtt's self-signed cert

### DIFF
--- a/MinisterIN.js
+++ b/MinisterIN.js
@@ -96,7 +96,7 @@ var mqttOptions = {
   port: mqttConfig.port,
   host: mqttConfig.host,
   protocol: 'mqtts',
-  rejectUnauthorized : true,
+  rejectUnauthorized : false,
   //The CA list will be used to determine if server is authorized
   ca: CA
 };


### PR DESCRIPTION
Beware that we are exposing ourselves to man in the middle attack, according to [this](https://www.npmjs.com/package/mqtt#client). The only way to avoid this is by not using a self-signed cert.
